### PR TITLE
Additional example configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ We will change that anyway in the later steps.
 
 # 6. Edit your device and change the config
 
-Now you just need to copy thte content of the [air-gradient.yaml](air-gradient.yaml) into the editor
+Now you just need to copy the content of the [air-gradient.yaml](air-gradient.yaml) into the editor.
+
+By default, [air-gradient.yaml](air-gradient.yaml) only records the particulate matter <2.5µm concentration that is measured by all PMSX003 sensors.
+The PMS5003 sensor (inlcuded with the AirGradient DIY kit) can also record <1.0µm and <10.0µm concentrations.
+Uncomment the sections for `pm_1_0` and `pm_10_0`, respectively, to record those as well.
+If you are using the PMS5003ST sensor, you can also record the formaldehyde (HCHO) concentration by uncommenting the `formaldehyde` section.
+See the [esphome docs](https://esphome.io/components/sensor/pmsx003.html) for details.
 
 # 7. Save and install
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Uncomment the sections for `pm_1_0` and `pm_10_0`, respectively, to record those
 If you are using the PMS5003ST sensor, you can also record the formaldehyde (HCHO) concentration by uncommenting the `formaldehyde` section.
 See the [esphome docs](https://esphome.io/components/sensor/pmsx003.html) for details.
 
+The OLED display is limited to four lines.
+You may display multiple pages by adding another page id section as in the [esphome docs](https://esphome.io/components/display/index.html#display-pages).
+An example second page showing three particulate matter sensors is included in [air-gradient.yaml](air-gradient.yaml).
+
 # 7. Save and install
 
 This will take a minute or two. ESPHome will compile the binary for your AirGradients ESP8266.

--- a/air-gradient.yaml
+++ b/air-gradient.yaml
@@ -52,6 +52,11 @@ display:
           it.printf(0, 10, id(opensans), "PM25: %.0f", id(pm25).state);
           it.printf(0, 20, id(opensans), "Hmdty: %.0f", id(humidity).state);
           it.printf(0, 30, id(opensans), "Temp: %.0fC", id(temp).state);
+#      - id: page2
+#        lambda: |-
+#          it.printf(0, 0, id(opensans), "PM10 : %.0f", id(pm10).state);
+#          it.printf(0, 10, id(opensans), "PM25 : %.0f", id(pm25).state);
+#          it.printf(0, 20, id(opensans), "PM100: %.0f", id(pm100).state);
 # Maybe add a page later
 
 interval:

--- a/air-gradient.yaml
+++ b/air-gradient.yaml
@@ -83,11 +83,22 @@ sensor:
     update_interval: 5s
 
   - platform: pmsx003
-    type: PMS5003T
+    # type can be PMSX003, PMS5003S, PMS5003T, PMS5003ST
+    # https://esphome.io/components/sensor/pmsx003.html
+    type: PMSX003
     uart_id: uart1
+#    pm_1_0:
+#      id: pm10
+#      name: "Particulate Matter <1.0µm Concentration"
     pm_2_5:
       id: pm25
       name: "Particulate Matter <2.5µm Concentration"
+#    pm_10_0:
+#      id: pm100
+#      name: "Particulate Matter <10.0µm Concentration"
+#    formaldehyde:
+#      id: hcho
+#      name: "Formaldehyde (HCHO) concentration in µg per cubic meter"
 
   - platform: senseair
     uart_id: uart2


### PR DESCRIPTION
Thank you for sharing this configuration it helped me get started quickly. I've included some optional configurations that suited my needs and possibly others, commented out so that they are not included by default. Please consider the following changes.

I noticed that the sensor that was included with my kit from Air Gradient was the PMS5003, not the PMS5003T used by the default configuration. I think switching to the "generic" PMS5003 by default is a good default.

Only measuring the PM2.5 by default is a good choice since it is measured by all sensors supported by ESPHome. On the other hand, the PMS5003 comes with the kit so I figure adding the options will be helpful to some. I also added formaldehyde for those who choose that sensor.

I added an example second page for those who measure the additional PM levels because they cannot all fit on a single page.

All options are included in the updated readme.