### PR TITLE
Renamed uart_id due to ESPHome breaking change

### DIFF
--- a/air-gradient-diy.yaml
+++ b/air-gradient-diy.yaml
@@ -86,12 +86,12 @@ uart:
   - rx_pin: D5
     tx_pin: D6
     baud_rate: 9600
-    id: uart1
+    id: uart_1
     
   - rx_pin: D4
     tx_pin: D3
     baud_rate: 9600
-    id: uart2
+    id: uart_2
 
 sensor:
   - platform: sht3xd
@@ -108,7 +108,7 @@ sensor:
     # type can be PMSX003, PMS5003S, PMS5003T, PMS5003ST
     # https://esphome.io/components/sensor/pmsx003.html
     type: PMSX003
-    uart_id: uart1
+    uart_id: uart_1
 #    pm_1_0:
 #      id: pm10
 #      name: "Particulate Matter <1.0µm Concentration"
@@ -123,7 +123,7 @@ sensor:
 #      name: "Formaldehyde (HCHO) concentration in µg per cubic meter"
 
   - platform: senseair
-    uart_id: uart2
+    uart_id: uart_2
     co2:
       id: co2
       name: "SenseAir CO2 Value"

--- a/air-gradient-pro-presoldered.yaml
+++ b/air-gradient-pro-presoldered.yaml
@@ -77,12 +77,12 @@ uart:
   - rx_pin: D5
     tx_pin: D6
     baud_rate: 9600
-    id: uart1
+    id: uart_1
     
   - rx_pin: D4
     tx_pin: D3
     baud_rate: 9600
-    id: uart2
+    id: uart_2
 
 sensor:
   - platform: sht3xd
@@ -97,7 +97,7 @@ sensor:
     
   - platform: pmsx003
     type: PMSX003
-    uart_id: uart1
+    uart_id: uart_1
     pm_2_5:
       id: pm25
       name: "${upper_devicename} Particulate Matter <2.5µm Concentration"
@@ -109,7 +109,7 @@ sensor:
 #      name: "Formaldehyde (HCHO) concentration in µg per cubic meter"
       
   - platform: senseair
-    uart_id: uart2
+    uart_id: uart_2
     co2:
       id: co2
       name: "${upper_devicename} SenseAir CO2 Value"


### PR DESCRIPTION
ESPHome 2023.4.0 now blocks the use of uart0 / uart1 / uart2 in the config. Following the recommendation in the changelog to replace them with uart_1 and uart_2
See https://esphome.io/changelog/2023.4.0.html#uart-ids