### PR TITLE
Update README.md with note about the usb ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ or you can just include your Home Assistant `secrets.yaml`:
 
 # 4. Plug in your AirGradient
 
-You can either plug it in the device running Home Assistant or your laptop/PC.
+You can either plug it in the device running Home Assistant or your laptop/PC. 
+Note: You must plug into the D1 Mini, not the D1 Mini Shield. The shield's USB port is only used for power.
 
 # 5. Add a new device
 


### PR DESCRIPTION
I foolishly spent hours chasing my own shadow, just to find out I had used the wrong USB port. For context, I have the pre-soldered version and thought the USB port that is exposed outside the case was the one to plug into for flashing. It never showed up in the list of devices to install to in ESPHome, since it is only for power input. 

Maybe this note can help others not do the same.