### PR TITLE
Change default SHT temperature sensor to sht4x, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,20 @@ I have written a blog post about this here: [Measuring Air Quality in your Home 
 
 # 1. Add the ESPHome addon
 
-Klick here: [![Open the ESPHome Add-n.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome)
+Click here: [![Open the ESPHome Add-n.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome)
+
+Note: This deep link won't work if you're running Home Assistant in Docker. In that case you'll need to install
+ESPHome via Docker or manually: https://esphome.io/guides/getting_started_command_line.html
+
+Eg: `docker run -d --name=esphome --net=host -e TZ=YOUR_TZ_VALUE -v YOUR_ESPHOME_CONFIG_FOLDER:/config esphome/esphome`
 
 # 2. Download whatever font you feel fancy.
 
 Follow the [ESPHome font docs](https://esphome.io/components/display/index.html#drawing-static-text)
+
+- Copy your font into the ESPHome directory (if running in Docker, the folder mapped to the `/config` mount point).
+- Change the font config with the path to your font:
+  eg. swap `- file: "gfonts://Ubuntu"` with `- file: "./yourfont.ttf"`
 
 # 3. Add your secrets
 
@@ -44,10 +53,14 @@ fallback_ssid_password: ""
 or you can just include your Home Assistant `secrets.yaml`:
 [How do I use my Home Assistant secrets.yaml?](https://esphome.io/guides/faq.html?highlight=secret#how-do-i-use-my-home-assistant-secrets-yaml)
 
+If you are using the ESPHome web interface you can edit the `secrets.yaml` via a button in the top
+right of the page.
+
 # 4. Plug in your AirGradient
 
 You can either plug it in the device running Home Assistant or your laptop/PC. 
-Note: You must plug into the D1 Mini, not the D1 Mini Shield. The shield's USB port is only used for power.
+Note: You must plug into the D1 Mini itself, not the D1 Mini Shield or external USB port of the Airgradient case.
+The shield's USB port is only used for power.
 
 # 5. Add a new device
 

--- a/air-gradient-pro-diy.yaml
+++ b/air-gradient-pro-diy.yaml
@@ -6,6 +6,8 @@
 # Instructions:
 # - Update your device id in `substitutions`
 # - Select your temperature unit in `substitutions`
+# - Select whether you have sht4x or sht3xd just above `temperature:`
+#   (Airgradient moving to sht4x: https://forum.airgradient.com/t/sht31-vs-sht40-do-either-work/1104/3)
 # - If you have the VOC/NOx sensor installed, uncomment `platform: sgp4x` and page3 of `display`
 #
 
@@ -206,15 +208,18 @@ uart:
     id: uart_2
 
 sensor:
+  # If your SHT sensor says "sht3x" on it replace platform with `sht3xd`
   # https://esphome.io/components/sensor/sht3xd.html
-  - platform: sht3xd
+  # - platform: sht3xd
+
+  - platform: sht4x
     temperature:
       id: temp
       name: ${upper_devicename} Temperature
     humidity:
       id: humidity
       name: ${upper_devicename} Relative Humidity
-    address: 0x44
+    address: 0x44 # Same for both sht3x and sht4x
     update_interval: 10s
 
   # https://esphome.io/components/sensor/pmsx003.html


### PR DESCRIPTION
Change default SHT temperature sensor to sht4x, add comments.

Airgradient now uses sht4x sensor by default, see
https://forum.airgradient.com/t/sht31-vs-sht40-do-either-work/1104/3

Verified working on my PCB v4.2

Improve README

- Add instructions for when deep link doesn't work (Home assistant in
  Docker)
- Add info how to access secrets.yaml
- Add that USB port on outside of Airgradient case is unsuitable for USB
  flashing

Thanks for all your work!